### PR TITLE
Update Qmi8658c.cpp

### DIFF
--- a/src/Qmi8658c.cpp
+++ b/src/Qmi8658c.cpp
@@ -90,7 +90,7 @@ uint8_t Qmi8658c::qmi8658_read(uint8_t reg) {
         // Wait
         // timout for breaking the loop
         if (millis() - startTime > 1000) 
-         return;
+         break;
     }
 
     // Read data from the register


### PR DESCRIPTION
Fixed compile error on line 93. Used blank return statement instead of break statement which is not allowed when function has a return value of uint8_t.